### PR TITLE
`Enumerable` `Find`, better performance

### DIFF
--- a/spec/find_spec.cr
+++ b/spec/find_spec.cr
@@ -70,10 +70,10 @@ describe Find do
 
   it "can prune entries out of the list of paths" do
     with_tmpdir do |tempdir|
-      File.open("#{tempdir}/a", "w"){}
+      File.open("#{tempdir}/a", "w") { }
       Dir.mkdir("#{tempdir}/b")
-      File.open("#{tempdir}/b/a", "w"){}
-      File.open("#{tempdir}/b/b", "w"){}
+      File.open("#{tempdir}/b/a", "w") { }
+      File.open("#{tempdir}/b/b", "w") { }
       Dir.mkdir("#{tempdir}/c")
       a = [] of String?
       Find.find(tempdir) do |f|

--- a/src/find.cr
+++ b/src/find.cr
@@ -5,17 +5,20 @@ module Find
     next Find::Skip
   end
 
+  # Skips dangling symlinks for compatibility with ruby
   def self.find(*paths)
+    super(*paths) do |path|
+      exists = File.exists?(path) rescue false
+      yield(path) if exists
+    end
+  end
+  
+  def self.find_all(*paths)
     paths.each do |path|
       search_path = [path]
       while !search_path.empty?
         file = search_path.shift
-
-        begin
-          next if file.nil? || !File.exists?(file)
-        rescue
-          next
-        end
+        next if file.nil?
 
         skip = yield file.dup
         next if skip == Find::Skip

--- a/src/find.cr
+++ b/src/find.cr
@@ -1,4 +1,6 @@
-module Find
+class Find
+  include Enumerable({Path, File::Info})
+
   struct Skip; end
 
   macro prune
@@ -7,35 +9,49 @@ module Find
 
   # Skips dangling symlinks for compatibility with ruby
   def self.find(*paths)
-    find_with_stat(*paths) do |path, info|
+    paths = paths.compact_map { |path| Path[path] }
+
+    new(paths).each do |path, info|
       exists = File.exists?(path) rescue false
-      yield(path) if exists
+      yield(path.to_s) if exists
     end
   end
-  
-  def self.find_with_info(*paths)
-    paths.each do |path|
-      search_path = [path]
-      while !search_path.empty?
-        file = search_path.shift
-        next if file.nil?
 
-        info = File.info?(file)
+  def self.new(paths : Enumerable(String?))
+    new paths.compact_map { |path| Path.new(path) }
+  end
+
+  def initialize(@paths : Enumerable(Path))
+  end
+
+  def each
+    search_path = [] of Path
+    @paths.each do |path|
+      search_path << path
+      while !search_path.empty?
+        file = search_path.pop
+
+        info = File.info?(file, follow_symlinks: false)
         next unless info # File deleted beteen list and now
-      
-        skip = yield file, info
+
+        skip = yield({file.not_nil!, info.not_nil!})
         next if skip == Find::Skip
 
         if info.directory?
           begin
             fs = Dir.children(file)
-          rescue
+          rescue ex
+            dir_children_error ex
             next
           end
 
-          fs.sort.reverse!.each { |f| search_path.unshift(File.join(file, f)) }
+          fs.sort.reverse!.each { |f| search_path.push(file.join(f)) }
         end
       end
     end
+  end
+
+  # Override
+  protected def dir_children_error(ex) : Nil
   end
 end

--- a/src/find.cr
+++ b/src/find.cr
@@ -7,7 +7,9 @@ class Find
     next Find::Skip
   end
 
-  # Skips dangling symlinks for compatibility with ruby
+  # For ruby compatibility
+  #
+  # * Skips dangling symlinks
   def self.find(*paths)
     paths = paths.compact_map { |path| Path[path] }
 
@@ -15,6 +17,10 @@ class Find
       exists = File.exists?(path) rescue false
       yield(path.to_s) if exists
     end
+  end
+
+  def self.new(*paths)
+    new paths.compact_map { |path| Path[path] }
   end
 
   def self.new(paths : Enumerable(String?))


### PR DESCRIPTION
`Find` is `Enumerable` and yields `{Path, File::Info}`
Use `push`/`pop` instead of `shift`/`unshift`
`follow_symlinks: false` to avoid infinite loops

### Benchmarks

Before
```
 Find.find double stat   1.03k (970.82µs) (± 3.70%)  53.2kB/op        fastest
```

After
```
 Find.find double stat   2.72M (367.65ns) (± 5.59%)   224B/op   4.96× slower
  Find.new double stat  12.63M ( 79.19ns) (± 7.76%)  96.0B/op   1.07× slower
  Find.new single stat  13.50M ( 74.09ns) (± 9.76%)  96.0B/op        fastest
```

`Find.new double stat` doesn't perform `File.exists` explaining the speed boost from `Find.find double stat`.
All `double stat` runs are for comparison with the original code.

Benchmark:
```crystal
require "benchmark"
require "./src/find"

stats = Hash(Symbol, Int32).new { |h, k| h[k] = 0 }

Benchmark.ips do |bm|
  bm.report "Find.find double stat" do
    stats.clear
    Find.find(".") do |path|
      if info = File.info? path, follow_symlinks: false
        if info.file?
          stats[:file] += 1
        elsif info.directory?
          stats[:dir] += 1
        end
      end
    end
  end

  bm.report "Find.new double stat" do
    stats.clear
    Find.new(["."]).each do |path, _|
      if info = File.info? path, follow_symlinks: false
        if info.file?
          stats[:file] += 1
        elsif info.directory?
          stats[:dir] += 1
        end
      end
    end
  end

  bm.report "Find.new single stat" do
    stats.clear
    Find.new(["."]).each do |path, info|
      if info.file?
        stats[:file] += 1
      elsif info.directory?
        stats[:dir] += 1
      end
    end
  end
end
```
